### PR TITLE
0328 1655 cws 컨트롤러 대시보드 수정

### DIFF
--- a/src/main/java/data/controller/TestController.java
+++ b/src/main/java/data/controller/TestController.java
@@ -13,12 +13,6 @@ import org.springframework.web.bind.annotation.RequestParam;
  */
 @Controller
 public class TestController {
-	//dashboard page
-	@RequestMapping("/")
-	public String hello() {
-		return "page1/dashboard";
-	}
-	
 	@GetMapping("/login")
 	public String login() {
 		return "page5/login";

--- a/src/main/java/data/controller/dashboard/DashBoardController.java
+++ b/src/main/java/data/controller/dashboard/DashBoardController.java
@@ -1,5 +1,10 @@
 package data.controller.dashboard;
 
-public class DashBoardController {
+import org.springframework.web.bind.annotation.RequestMapping;
 
+public class DashBoardController {
+	@RequestMapping("/dashboard")
+	public String hello() {
+		return "page1/dashboard";
+	}
 }

--- a/src/main/resources/templates/page1/dashboard.html
+++ b/src/main/resources/templates/page1/dashboard.html
@@ -8,6 +8,17 @@
 <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css">
 <style type="text/css">
+	/* 페이드인 효과 */
+	.fade-in {
+	    opacity: 0;
+	    animation: fadeIn 1.5s ease-in forwards;
+	}
+
+	@keyframes fadeIn {
+	    from { opacity: 0; }
+	    to { opacity: 1; }
+	}
+	
 	.box {
 		weight: 412px;
 		height: auto;


### PR DESCRIPTION
- 테스트 컨트롤러에서 page1/dashboard로 되어있던 것 소거
- 대시보드 컨트롤러에 "/dashboard" 경로를 통해서 각종 통계, 서치 트렌드, 뉴스 기사 등을 확인할 수 있도록 매핑 추가
- 대시보드 html 코드에서 fade-in css 추가 (이 부분은 중간 발표 이후 추가 예정, 차후 은영님이 전담해서 깃 충돌 가능성 최소화) 